### PR TITLE
remove postinstall from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "main": "src/gama.js",
   "scripts": {
-    "postinstall": "gulp dist",
     "lint": "gulp linter",
     "test": "gulp test"
   },


### PR DESCRIPTION
The postinstall script causes an error when you do 

```
npm install https://github.com/honzabrecka/gama.git
```

![image](https://cloud.githubusercontent.com/assets/2136203/8018733/ea3b4d8c-0bef-11e5-92a0-81332c77518d.png)
